### PR TITLE
[Fish] Item & Recipe Class Added

### DIFF
--- a/Assets/Scripts/ItemClass/Item.cs
+++ b/Assets/Scripts/ItemClass/Item.cs
@@ -1,18 +1,12 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
-public class Item : MonoBehaviour
+[Serializable]
+public class Item
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
+    public int itemID;
+    public string itemName;
+    public bool sellAble;
+    public int sellPrice;
+    public bool buyAble;
+    public int buyPrice;
 }

--- a/Assets/Scripts/ItemClass/Item.cs
+++ b/Assets/Scripts/ItemClass/Item.cs
@@ -5,8 +5,6 @@ public class Item
 {
     public int itemID;
     public string itemName;
-    public bool sellAble;
     public int sellPrice;
-    public bool buyAble;
     public int buyPrice;
 }

--- a/Assets/Scripts/ItemClass/Recipe.cs
+++ b/Assets/Scripts/ItemClass/Recipe.cs
@@ -1,11 +1,18 @@
 using System;
 
 [Serializable]
+public class ItemHandler
+{
+    public int ID;
+    public int num;
+}
+[Serializable]
 public class Recipe
 {
     public int recipeID;
     public string recipeName;
-    public int[] ingredientID;
+    public ItemHandler[] ingredient;
     public int[] machineID;
     int dayRequired;
+    public ItemHandler result;
 }

--- a/Assets/Scripts/ItemClass/Recipe.cs
+++ b/Assets/Scripts/ItemClass/Recipe.cs
@@ -1,18 +1,11 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
-public class Recipe : MonoBehaviour
+[Serializable]
+public class Recipe
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
+    public int recipeID;
+    public string recipeName;
+    public int[] ingredientID;
+    public int[] machineID;
+    int dayRequired;
 }


### PR DESCRIPTION
## Summary

Item Class 추가
Recipe Class 추가

<br>

## Description

Item 클래스를 추가, 다만 각 가공품, 시설 등의 아이템의 작동 방식이 다르기에 이를 사용할 수 있는지 여부 확실하지 않음
Recipe 클래스 추가, Recipe ID가 배정되어 있으며 Ingredient 의 ItemID와 개수, 사용해야 하는 MachineID를 저장하며, 이를 통해 result 아이템의 ItemID와 개수를 지정할 수 있다.

<br>

## Issue number

24 PR의 수정본이며, 잘 사용될지는 모르곘지만 잘 됬으면 좋겠다

<br>

## Others

![image](https://github.com/user-attachments/assets/d9662aab-8155-43cc-be08-1d59578988cf)